### PR TITLE
Fix for https://xebialabs.zendesk.com/agent/tickets/18326

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 plugins {
     id "java"
     id "com.github.hierynomus.license" version "0.13.1"
+    id "com.xebialabs.xl.docker" version "1.1.0"
 }
 
 // Repositories
@@ -9,6 +10,14 @@ repositories {
     maven {
         url 'http://dist.xebialabs.com/public/maven2'
     }
+}
+
+xlDocker {
+    compileImage = 'xebialabsunsupported/xlr_dev_compile'
+    compileVersion = '9.0'
+    runImage = 'xebialabsunsupported/xlr_dev_run'
+    runVersion = '9.0'
+    runPortMapping = '5516:5516'
 }
 
 // Defaults

--- a/src/main/resources/blazemeter/ConnectionCheck.py
+++ b/src/main/resources/blazemeter/ConnectionCheck.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2020 XEBIALABS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import base64
+from blazemeter.common import (call_url, encode_multipart)
+
+# Initialize variables
+user_url = ''
+data = ''
+headers = {}
+
+# Add headers
+base64string = base64.encodestring('%s:%s' % (configuration.api_key_id, configuration.api_key_secret)).replace('\n', '')
+headers['Authorization'] = 'Basic %s' % base64string
+headers['Content-Type'] = 'application/json'
+
+# Call the user api to see if we can make a connection to the server
+user_url = '%s/user' % configuration.url
+data = call_url('get', user_url, None, headers)
+# If we don't throw an error in common.py, we are good to go.  All error handling is done in common.py

--- a/src/main/resources/blazemeter/common.py
+++ b/src/main/resources/blazemeter/common.py
@@ -123,15 +123,27 @@ def call_url(verb, url, data, headers):
     # Catch all exceptions
     except urllib2.HTTPError as error:
         print 'FATAL: HTTP %s error! %s (URL: %s)\n' % (error.code, error.msg, url)
+        raise Exception(
+            "Failed to connect to Blazemeter Server. Code: %s Message: %s" % (error.code, error.msg)
+        )
         sys.exit(202)
     except urllib2.URLError as error:
         print 'FATAL: Network error! %s\n' % error.reason
+        raise Exception(
+            "Failed to connect to Blazemeter Server. Code: %s Message: %s" % (error.code, error.msg)
+        )
         sys.exit(203)
     except ValueError as error:
         print 'FATAL: JSON parsing error! %s\n' % error.message
+        raise Exception(
+            "Failed to connect to Blazemeter Server. Code: %s Message: %s" % (error.code, error.msg)
+        )
         sys.exit(204)
     except Exception as error:
         print 'FATAL: Uncaught error! %s\n' % error
+        raise Exception(
+            "Failed to connect to Blazemeter Server. Code: %s Message: %s" % (error.code, error.msg)
+        )
         sys.exit(205)
 
     return output

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -9,7 +9,15 @@
 
 <synthetic xsi:schemaLocation="http://www.xebialabs.com/deployit/synthetic synthetic.xsd"
            xmlns="http://www.xebialabs.com/deployit/synthetic"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">        
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!-- Global configuration -->
+    <type type="blazemeter.Server" extends="xlrelease.Configuration">
+        <property name="scriptLocation" hidden="true" default="blazemeter/ConnectionCheck.py"/>
+        <property name="url" required="true" label="Server URL" default="https://a.blazemeter.com/api/v4" description="Address where the server can be reached - ex: https://a.blazemeter.com/api/v4"/>
+        <property name="api_key_id" required="true" label="API Key ID" description="The API key id for the user account" />
+        <property name="api_key_secret" required="true" label="API Key Secret" description="The API key secret for the user account" />
+    </type>
 
     <!-- Run a test -->
     <type type="blazemeter.RunTest" extends="xlrelease.PythonScript" description="Run a preconfigured test">
@@ -47,10 +55,4 @@
             description="The list (one row per line item) of test data to add. Use a tuple for comma-separated values" />
         <property name="filename" category="input" required="true" label="Filename" description="The filename to use when uploading the test data file" />
     </type>   
-
-    <!-- Global configuration -->
-    <type type="blazemeter.Server" extends="xlrelease.Configuration">
-        <property name="url" label="BlazeMeter URL" required="true" description="BlazeMeter RESTful API URL" />
-    </type>
- 
 </synthetic>


### PR DESCRIPTION
Code review by:  Amit Mohleji

Added logic to allow user to test connection to the blazemeter server by providing an api key id and api key secret.  These values must be created in blazemeter.  To generate an API key pair, see:  https://guide.blazemeter.com/hc/en-us/articles/115002213289-BlazeMeter-API-keys-